### PR TITLE
fix gha set-output command

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Retrieve Version
         if: startsWith(github.ref, 'refs/tags/')
         id: get_tag_version
-        run: echo ::set-output name=TAG_VERSION::${GITHUB_REF/refs\/tags\//}
+        run: echo "TAG_VERSION=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_OUTPUT
       - uses: actions/setup-node@v3
         with:
           node-version: "16.x"


### PR DESCRIPTION
GitHub is going to deprecate `save-state` and `set-output` commands. [More info](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)

This PR adjusts GHA workflow to use new syntax.

Part of https://github.com/paritytech/ci_cd/issues/805